### PR TITLE
[syntacore] tcl/syntacore: do not modify `*counteren` in HPM setup

### DIFF
--- a/tcl/syntacore/sc_fpga_lib.tcl
+++ b/tcl/syntacore/sc_fpga_lib.tcl
@@ -132,17 +132,6 @@ namespace eval _SC_INTERNALS {
             sc_lib_print "[sc_lib_write_reg mhpmevent${EventSelector} 0]"
             sc_lib_print "[sc_lib_write_reg mhpmcounter${EventSelector} 0]"
         }
-        set REG_LIST [reg]
-        if {[string match "* mcounteren *" "$REG_LIST"]} {
-          sc_lib_print "[sc_lib_write_reg mcounteren 0xffffffff]"
-        } else {
-          sc_lib_print "NOTE: mcounteren is not found on target"
-        }
-        if {[string match "* scounteren *" "$REG_LIST"]} {
-          sc_lib_print "[sc_lib_write_reg scounteren 0xffffffff]"
-        } else {
-          sc_lib_print "NOTE: scounteren is not found on target"
-        }
     }
 
     proc sc_lib_experimental_enable_pmu_counters { selectors_list


### PR DESCRIPTION
The RISC-V Instruction Set Manual: Volume II: Privileged Architecture Version 20241101 [3.1.11. Machine Counter-Enable (mcounteren) Register] states:
> The settings in this register only control accessibility. The act of
reading or writing this register does not affect the underlying counters, which continue to increment even when not accessible.

Therefore, there is no need to adjust it's value when setting-up HPM counters.

Change-Id: I083912ce3a8762ef33f805b71baa099cbf3d6a78