### PR TITLE
[syntacore] drop Syntacore extensions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -402,10 +402,6 @@ AC_ARG_ENABLE([remote-bitbang],
   AS_HELP_STRING([--enable-remote-bitbang], [Enable building support for the Remote Bitbang driver]),
   [build_remote_bitbang=$enableval], [build_remote_bitbang=yes])
 
-AC_ARG_ENABLE([syntacore-extensions],
-  AS_HELP_STRING([--enable-syntacore-extensions], [Enable Syntacore extensions.]),
-  [syntacore_extensions=$enableval], [syntacore_extensions=no])
-
 AS_CASE(["${host_cpu}"],
   [i?86|x86*], [],
   [
@@ -649,13 +645,6 @@ AS_IF([test "x$enable_capstone" == xno], [
 	AC_DEFINE([HAVE_CAPSTONE], [0], [0 if you don't have Capstone disassembly framework.])
 ])
 
-AS_IF([test "x$enable_syntacore_extensions" = xyes], [
-		PKG_CHECK_MODULES([JANSSON], [jansson])
-		AC_DEFINE([SYNTACORE_EXTENSIONS],[1], [1 if SYNTACORE_EXTENSIONS support is included.])
-	], [
-		AC_DEFINE([SYNTACORE_EXTENSIONS],[0], [0 if SYNTACORE_EXTENSIONS support is excluded.])
-])
-
 for hidapi_lib in hidapi hidapi-hidraw hidapi-libusb; do
 	PKG_CHECK_MODULES([HIDAPI],[$hidapi_lib],[
 		use_hidapi=yes
@@ -746,7 +735,6 @@ AS_IF([test "x$enable_esp_usb_jtag" != "xno"], [
 ])
 
 AM_CONDITIONAL([RELEASE], [test "x$build_release" = "xyes"])
-AM_CONDITIONAL([SYNTACORE_RELEASE], [test "x$build_syntacore_release" = "xyes"])
 AM_CONDITIONAL([PARPORT], [test "x$build_parport" = "xyes"])
 AM_CONDITIONAL([GIVEIO], [test "x$parport_use_giveio" = "xyes"])
 AM_CONDITIONAL([EP93XX], [test "x$build_ep93xx" = "xyes"])
@@ -775,8 +763,6 @@ AM_CONDITIONAL([USE_LIBJAYLINK], [test "x$use_libjaylink" = "xyes"])
 AM_CONDITIONAL([RSHIM], [test "x$build_rshim" = "xyes"])
 AM_CONDITIONAL([DMEM], [test "x$build_dmem" = "xyes"])
 AM_CONDITIONAL([HAVE_CAPSTONE], [test "x$enable_capstone" != "xno"])
-
-AM_CONDITIONAL([SYNTACORE_EXTENSIONS], [test "x$enable_syntacore_extensions" = "xyes"])
 
 AM_CONDITIONAL([HAVE_JIMTCL_PKG_CONFIG], [test "x$have_jimtcl_pkg_config" = "xyes"])
 

--- a/src/openocd.c
+++ b/src/openocd.c
@@ -33,10 +33,6 @@
 #include <server/gdb_server.h>
 #include <server/rtt_server.h>
 
-#if SYNTACORE_EXTENSIONS
-#include <target/embargo/sc-ext/cmd.h>
-#endif
-
 #ifdef HAVE_STRINGS_H
 #include <strings.h>
 #endif
@@ -251,9 +247,6 @@ static int (* const command_registrants[])(struct command_context *cmd_ctx_value
 	cti_register_commands,
 	dap_register_commands,
 	arm_tpiu_swo_register_commands,
-#if SYNTACORE_EXTENSIONS
-	&syntacore_extensions_register_commands,
-#endif
 };
 
 static struct command_context *setup_command_handler(Jim_Interp *interp)
@@ -368,9 +361,6 @@ int openocd_main(int argc, char *argv[])
 	/* free all DAP and CTI objects */
 	arm_cti_cleanup_all();
 	dap_cleanup_all();
-#if SYNTACORE_EXTENSIONS
-	syntacore_extensions_cleanup();
-#endif
 
 	adapter_quit();
 

--- a/src/target/Makefile.am
+++ b/src/target/Makefile.am
@@ -242,9 +242,3 @@ include %D%/openrisc/Makefile.am
 include %D%/riscv/Makefile.am
 include %D%/xtensa/Makefile.am
 include %D%/espressif/Makefile.am
-
-if SYNTACORE_EXTENSIONS
-include %D%/embargo/sc-ext/Makefile.am
-%C%_libtarget_la_LIBADD += %D%/embargo/sc-ext/libscext.la
-endif
-


### PR DESCRIPTION
Remove the `--enable-syntacore-extensions` configure argument and related machinery.

Change-Id: I9c0251af6490b22bf26ef93c6e11cc30518142d4