### PR TITLE
fix translation of kernel addresses in sv57 mode

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -272,7 +272,7 @@ static const virt2phys_info_t sv57 = {
 	.pte_ppn_shift = {10, 19, 28, 37, 46},
 	.pte_ppn_mask = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0xff},
 	.pa_ppn_shift = {12, 21, 30, 39, 48},
-	.pa_ppn_mask = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0xff},
+	.pa_ppn_mask = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff},
 };
 
 static const virt2phys_info_t sv57x4 = {


### PR DESCRIPTION
In SV57 **virtual** addresses look as follows:

```
+--------+---------+---------+---------+---------+---------+-----------+
|copy of |  VPN[4] |  VPN[3] |  VPN[2] |  VPN[1] |  VPN[0] |  OFFSET   |
| bit 56 |  9 bits |  9 bits |  9 bits |  9 bits |  9 bits |  12 bits  |
+--------+---------+---------+---------+---------+---------+-----------+
| 63  57 | 56   48 | 47   40 | 39   32 | 31   24 | 23   12 | 11      0 |
```

while the structure of **physical** address is:

```
+------------+----------+----------+---------+----------+-----------+
|   PPN[4]   |  PPN[3]  |  PPN[2]  | PPN[1]  |  PPN[0]  |  OFFSET   |
|   8 bits   |  9 bits  |  9 bits  | 9 bits  |  9 bits  |  12 bits  |
+------------+----------+----------+---------+----------+-----------+
| 55      48 | 47    39 | 38    30 | 29   21 | 20    12 | 11      0 |
```

So the size of effective VA is 57, while PA is 56 bits.

When our translation routine constructs the final physical address, it preserves a portion of the original virtual address (to handle superpage cases). To mask out the part of the original VA that must be replaced with the PPN from the PTE, the **virt2phys_info_t::pa_ppn_mask** field is used.

In our codebase pa_ppn_mask[4] was initialized incorrectly for SV57 mode, resulting  in a single bit from the original VA to leak through, producing an incorrect physical address.