### PR TITLE
Revert "[syntacore] tools/syntacore: add N extension registers to IDE…

### DIFF
--- a/tools/syntacore/ide_cloak.tcl
+++ b/tools/syntacore/ide_cloak.tcl
@@ -105,10 +105,6 @@ proc generateIdeCloak { } {
     vtype \
     vxrm \
     vxsat \
-    sedeleg \
-    sideleg \
-    uscratchcsw \
-    uscratchcswl \
   ]
 
   set CSRS_TO_HIDE [generateListOfCloakedAddresses $IDE_CSRS]


### PR DESCRIPTION
… cloack"

This reverts commit 00f4386d536379fefe71c90803c8839f2c861336.

The list in `ide_cloak.tcl` is a list of registers that should be exposed, so adding registers to that list to hide them is a mistake.

Change-Id: I7c76aedc99f86949acbf05300af5dfa8ec5c9697