### PR TITLE
openocd_run.exp: match "." symbol at the end of rbb port

### DIFF
--- a/tools/syntacore/openocd_run.exp
+++ b/tools/syntacore/openocd_run.exp
@@ -907,7 +907,7 @@ proc runSpikeIfNeeded {} {
   spawn $SpikeBinary {*}$SpikeArgs
   send_user -- "==== Spawned Spike PID=[exp_pid -i $spawn_id] ====\n"
   expect {
-    -re "Listening for remote bitbang connection on port (\[0-9\]+)" {
+    -re {Listening for remote bitbang connection on port ([1-9][0-9]*)\.} {
       set MatchedBitbangPort $expect_out(1,string)
       send_user -- "spike launched successfully! bitbang_port = $MatchedBitbangPort\n"
       if {$SETTINGS(bitbang_port) == 0} {


### PR DESCRIPTION
The RBB port should end with "." symbol, without it the script could theoretically match the wrong (truncated) value.