### PR TITLE
target/riscv: do not cache access to vxrm, vxsat and vcsr

### DIFF
--- a/src/target/riscv/riscv_reg_impl.h
+++ b/src/target/riscv/riscv_reg_impl.h
@@ -195,8 +195,6 @@ static inline bool riscv_reg_impl_gdb_regno_cacheable(enum gdb_regno regno,
 	 * CSRs. */
 	switch (regno) {
 		case GDB_REGNO_DPC:
-		case GDB_REGNO_VXSAT:
-		case GDB_REGNO_VXRM:
 		case GDB_REGNO_VLENB:
 		case GDB_REGNO_MISA:
 		case GDB_REGNO_DCSR:
@@ -215,6 +213,9 @@ static inline bool riscv_reg_impl_gdb_regno_cacheable(enum gdb_regno regno,
 		case GDB_REGNO_VSTART: /* Changes value when vtype is changed. */
 		case GDB_REGNO_VL: /* Changes value when vtype is changed. */
 		case GDB_REGNO_VTYPE: /* Writes to vtype have side effects, so we don't cache it. */
+		case GDB_REGNO_VXSAT: /* Changes value when vcsr is changed. */
+		case GDB_REGNO_VXRM: /* Changes value when vcsr is changed. */
+		case GDB_REGNO_VCSR: /* Changes when vxrm or vxsat are changed. */
 		default:
 			return false;
 	}


### PR DESCRIPTION
Based On: https://review.openocd.org/c/openocd/+/9416/2

vxrm and vxsat registers are mirrored in vcsr, so we can't cache any of them.