### PR TITLE
Remove duplicate testing directory entries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,9 +34,6 @@ DIST_SUBDIRS += testing
 SUBDIRS += tools/syntacore
 DIST_SUBDIRS += tools/syntacore
 
-SUBDIRS += testing
-DIST_SUBDIRS += testing
-
 # common flags used in openocd build
 AM_CFLAGS = $(GCC_WARNINGS)
 AM_LDFLAGS =


### PR DESCRIPTION
The testing directory was accidentally added twice to both SUBDIRS and DIST_SUBDIRS. This caused `make distclean` to attempt cleaning the same directory twice; the second attempt failed because the Makefile had already been removed. Remove the duplicate lines to ensure each directory is processed only once.
The offending commit: 5b2a3b9fa4fe9b7c71d3ac4120738c4095fe6d81