### PR TITLE
target/target: drop the cached value when force-reading a register

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -3126,8 +3126,22 @@ COMMAND_HANDLER(handle_reg_command)
 	/* display a register */
 	if ((CMD_ARGC == 1) || ((CMD_ARGC == 2) && !((CMD_ARGV[1][0] >= '0')
 			&& (CMD_ARGV[1][0] <= '9')))) {
-		if ((CMD_ARGC == 2) && (strcmp(CMD_ARGV[1], "force") == 0))
+		if (CMD_ARGC == 2 && strcmp(CMD_ARGV[1], "force") == 0
+				&& reg->valid) {
+			if (reg->dirty) {
+				char *value = buf_to_hex_str(reg->value, reg->size);
+				if (!value) {
+					LOG_ERROR("Out of memory");
+					return ERROR_FAIL;
+				}
+				LOG_TARGET_WARNING(target,
+						"Discarding the cached write of 0x%s to register %s",
+						value, reg->name);
+				free(value);
+				reg->dirty = false;
+			}
 			reg->valid = false;
+		}
 
 		if (!reg->valid) {
 			int retval = reg->type->get(reg);


### PR DESCRIPTION
Consider the write of a GPR (cacheable) that is followed by a force read. After the write the GPR is valid and dirty.
When force reading, before the patch, the valid bit was cleared. This makes the state of the register upon entry to `reg->get()` nonsensical, i.e.:
* `valid` is low, meaning the value in the cache is not the most recent value of the register and needs to be updated.
* `dirty` is high, mening the value in the cache is more recent then the value on the target, so the register on the target needs to be updated with the value from the cache.

There are two behaviors possible here:
1. Update the value on the target, using the value from the cache before reading.
2. Discard the value in the cache.

(1) is more preferable since it guarantees correctness (i.e. on a propery-working cacheable register reading and force-reading the register will always result in the same value). Unfortunately, it is not readily available, since there needs to be an additional register method: `reg->flush()`. See [1] for more details.

In the meantime, to avoid this inconsistent state of a cache entry, this patch introduces behavior (2). This will be problematic, e.g. on RISC-V platforms some registers are "saved" using the cache. This works as follows:
- "Save" the register in the cache, simply marking a valid cache entry as dirty.
- Performe (possibly multiple) operation that in the process change the value of this register as a side-effect.
- When needed to update the state of the target (e.g. on resume) the value from the cache will be written to the target, restoring the register value.

Now imagine the user force-reads a "saved" register. The original value will be dorpped and the clobbered value from the target (which depends on the operations and algorithms used) will be read into the cache and marked as valid.

1: https://review.openocd.org/c/openocd/+/8070

Change-Id: I69583a31e930050ec450a9b266a0350828199b47